### PR TITLE
Potential fix for code scanning alert no. 19: Clear-text logging of sensitive information

### DIFF
--- a/inmemory/api/server.py
+++ b/inmemory/api/server.py
@@ -107,7 +107,7 @@ class InMemoryAPI:
             if user_id:
                 logger.info(f"Valid API key for user: {user_id}")
                 return user_id
-            logger.warning(f"Invalid API key attempted: {api_key[:8]}...")
+            logger.warning("Invalid API key attempted.")
             return None
 
         except Exception as e:


### PR DESCRIPTION
Potential fix for [https://github.com/shrijayan/inmemory/security/code-scanning/19](https://github.com/shrijayan/inmemory/security/code-scanning/19)

To resolve this problem without impacting existing logic, the log statement on line 110 should be changed to *not log any portion of the API key at all*. It is possible to indicate that an invalid API key was attempted, but do not include the key value or substring in the log output. Instead, log a generic message (e.g., "Invalid API key attempted"). Only remove the sensitive value from the logger call; all other logic remains unchanged. No additional imports or new definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
