### PR TITLE
Potential fix for code scanning alert no. 42: Clear-text logging of sensitive information

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
 jobs:
   lint-and-format:
     name: Code Quality

--- a/selfmemory/cli.py
+++ b/selfmemory/cli.py
@@ -214,8 +214,8 @@ def stats_command(args):
             print(f"👥 Total Users: {stats.get('total_users', 0)}")
 
             if args.verbose:
-                print(f"🔑 Total API Keys: {stats.get('total_api_keys', 0)}")
-                print(f"🟢 Active API Keys: {stats.get('active_api_keys', 0)}")
+                # Omitted logging of total and active API keys to avoid exposing sensitive information.
+                
                 print("\n📋 Detailed Statistics:")
                 import json
 

--- a/selfmemory/cli.py
+++ b/selfmemory/cli.py
@@ -212,10 +212,10 @@ def stats_command(args):
 
             print(f"🗄️  Storage Type: {stats.get('storage_type', 'unknown')}")
             print(f"👥 Total Users: {stats.get('total_users', 0)}")
-            print(f"🔑 Total API Keys: {stats.get('total_api_keys', 0)}")
-            print(f"🟢 Active API Keys: {stats.get('active_api_keys', 0)}")
 
             if args.verbose:
+                print(f"🔑 Total API Keys: {stats.get('total_api_keys', 0)}")
+                print(f"🟢 Active API Keys: {stats.get('active_api_keys', 0)}")
                 print("\n📋 Detailed Statistics:")
                 import json
 


### PR DESCRIPTION
Potential fix for [https://github.com/SelfMemory/SelfMemory/security/code-scanning/42](https://github.com/SelfMemory/SelfMemory/security/code-scanning/42)

To address this issue, we should avoid logging (displaying) the number of active API keys unless it is specifically requested (e.g., via a `--verbose` flag). Since the code already checks for a `verbose` flag before showing detailed statistics, moving the logging of the active API key count (and potentially the total API key count) to the verbose section ensures sensitive information isn't printed by default. The primary change, then, is to only show the "Total API Keys" and "Active API Keys" (lines 215 and 216) if `args.verbose` is `True`. Otherwise, omit these from the default output.

**Steps:**
- In function `stats_command`, move lines printing API key statistics (`print(f"🔑 Total API Keys...")` and `print(f"🟢 Active API Keys...")`) into the `if args.verbose:` block.
- Ensure the rest of the code continues to display non-sensitive statistics as before.
- No new imports or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
