### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI/CD Pipeline
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/SelfMemory/SelfMemory/security/code-scanning/1](https://github.com/SelfMemory/SelfMemory/security/code-scanning/1)

The best way to fix this problem is to add an explicit `permissions` block that grants the minimal necessary permissions for the tasks in this workflow. Since there is no evidence in the shown code that any steps require write access to contents, issues, or pull requests, setting `contents: read` suffices for the vast majority of standard workflows (especially those doing lint/build/test only). The `permissions` block should be added at the workflow root (just below `name: CI/CD Pipeline`), which will apply to all jobs unless a more specific job-level `permissions` override is later added.

You only need to edit the `.github/workflows/ci.yml` file. Insert the following at the root level, just after the `name:` field and before the `on:` field:

```yaml
permissions:
  contents: read
```

No changes to steps, jobs, or imports are necessary, nor are any additional dependencies or definitions required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
